### PR TITLE
Dan: Fixed cohesive energy descriptions

### DIFF
--- a/properties/cohesive-potential-energy-cubic-crystal/2014-04-15-staff@noreply.openkim.org/cohesive-potential-energy-cubic-crystal.edn
+++ b/properties/cohesive-potential-energy-cubic-crystal/2014-04-15-staff@noreply.openkim.org/cohesive-potential-energy-cubic-crystal.edn
@@ -3,7 +3,7 @@
   
   "property-title" "Cohesive energy of cubic crystal structure at zero temperature"
 
-  "property-description" "Cohesive energy of a cubic crystal at zero temperature."
+  "property-description" "Cohesive energy (negative of the potential energy per atom) of a cubic crystal at zero temperature."
 
   "short-name" {
     "type"         "string"
@@ -59,6 +59,6 @@
     "has-unit"     true
     "extent"       []
     "required"     true
-    "description" "Cohesive potential energy of the cubic crystal at zero temperature." 
+    "description" "Cohesive energy (negative of the potential energy per atom) of the cubic crystal at zero temperature." 
   }
 }

--- a/properties/cohesive-potential-energy-hexagonal-crystal/2014-04-15-staff@noreply.openkim.org/cohesive-potential-energy-hexagonal-crystal.edn
+++ b/properties/cohesive-potential-energy-hexagonal-crystal/2014-04-15-staff@noreply.openkim.org/cohesive-potential-energy-hexagonal-crystal.edn
@@ -3,7 +3,7 @@
   
   "property-title" "Cohesive energy of hexagonal crystal structure at zero temperature"
 
-  "property-description" "Cohesive energy of a hexagonal crystal at zero temperature."
+  "property-description" "Cohesive energy (negative of the potential energy per atom) of a hexagonal crystal at zero temperature."
 
   "short-name" {
     "type"         "string"
@@ -66,6 +66,6 @@
     "has-unit"     true
     "extent"       []
     "required"     true
-    "description" "Cohesive potential energy of the hexagonal crystal at zero temperature." 
+    "description" "Cohesive energy (negative of the potential energy per atom) of the hexagonal crystal at zero temperature." 
   }
 }


### PR DESCRIPTION
- cohesive-potential-energy-cubic-crystal inadvertently had "isothermal bulk modulus" in its description.
- specified that cohesive energy is taken to be the negative of the potential energy in cohesive-potential-energy-cubic-crystal and cohesive-potential-energy-hexagona-crystal
