### PR TITLE
Dan: removed extra space put in from last commit

### DIFF
--- a/properties/bulk-modulus-isothermal-cubic-crystal-npt/2014-04-15-staff@noreply.openkim.org/bulk-modulus-isothermal-cubic-crystal-npt.edn
+++ b/properties/bulk-modulus-isothermal-cubic-crystal-npt/2014-04-15-staff@noreply.openkim.org/bulk-modulus-isothermal-cubic-crystal-npt.edn
@@ -37,21 +37,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "temperature" {

--- a/properties/bulk-modulus-isothermal-hexagonal-crystal-npt/2014-04-15-staff@noreply.openkim.org/bulk-modulus-isothermal-hexagonal-crystal-npt.edn
+++ b/properties/bulk-modulus-isothermal-hexagonal-crystal-npt/2014-04-15-staff@noreply.openkim.org/bulk-modulus-isothermal-hexagonal-crystal-npt.edn
@@ -44,21 +44,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "temperature" {

--- a/properties/cohesive-energy-relation-cubic-crystal/2014-04-15-staff@noreply.openkim.org/cohesive-energy-relation-cubic-crystal.edn
+++ b/properties/cohesive-energy-relation-cubic-crystal/2014-04-15-staff@noreply.openkim.org/cohesive-energy-relation-cubic-crystal.edn
@@ -37,21 +37,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "cohesive-energy" {

--- a/properties/cohesive-free-energy-cubic-crystal/2014-04-15-staff@noreply.openkim.org/cohesive-free-energy-cubic-crystal.edn
+++ b/properties/cohesive-free-energy-cubic-crystal/2014-04-15-staff@noreply.openkim.org/cohesive-free-energy-cubic-crystal.edn
@@ -37,21 +37,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "temperature" {

--- a/properties/cohesive-free-energy-hexagonal-crystal/2014-04-15-staff@noreply.openkim.org/cohesive-free-energy-hexagonal-crystal.edn
+++ b/properties/cohesive-free-energy-hexagonal-crystal/2014-04-15-staff@noreply.openkim.org/cohesive-free-energy-hexagonal-crystal.edn
@@ -44,21 +44,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "temperature" {

--- a/properties/cohesive-potential-energy-cubic-crystal/2014-04-15-staff@noreply.openkim.org/cohesive-potential-energy-cubic-crystal.edn
+++ b/properties/cohesive-potential-energy-cubic-crystal/2014-04-15-staff@noreply.openkim.org/cohesive-potential-energy-cubic-crystal.edn
@@ -1,6 +1,6 @@
 {
   "property-id" "tag:staff@noreply.openkim.org,2014-04-15:property/cohesive-potential-energy-cubic-crystal"
-  
+
   "property-title" "Cohesive energy of cubic crystal structure at zero temperature"
 
   "property-description" "Cohesive energy (negative of the potential energy per atom) of a cubic crystal at zero temperature."
@@ -37,21 +37,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "cohesive-potential-energy" {
@@ -59,6 +59,6 @@
     "has-unit"     true
     "extent"       []
     "required"     true
-    "description" "Cohesive energy (negative of the potential energy per atom) of the cubic crystal at zero temperature." 
+    "description" "Cohesive energy (negative of the potential energy per atom) of the cubic crystal at zero temperature."
   }
 }

--- a/properties/cohesive-potential-energy-hexagonal-crystal/2014-04-15-staff@noreply.openkim.org/cohesive-potential-energy-hexagonal-crystal.edn
+++ b/properties/cohesive-potential-energy-hexagonal-crystal/2014-04-15-staff@noreply.openkim.org/cohesive-potential-energy-hexagonal-crystal.edn
@@ -44,21 +44,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "cohesive-potential-energy" {

--- a/properties/elastic-constants-isothermal-cubic-crystal-npt/2014-05-21-staff@noreply.openkim.org/elastic-constants-isothermal-cubic-crystal-npt.edn
+++ b/properties/elastic-constants-isothermal-cubic-crystal-npt/2014-05-21-staff@noreply.openkim.org/elastic-constants-isothermal-cubic-crystal-npt.edn
@@ -37,21 +37,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "temperature" {

--- a/properties/phonon-dispersion-dos-cubic-crystal-npt/2014-05-21-staff@noreply.openkim.org/phonon-dispersion-dos-cubic-crystal-npt.edn
+++ b/properties/phonon-dispersion-dos-cubic-crystal-npt/2014-05-21-staff@noreply.openkim.org/phonon-dispersion-dos-cubic-crystal-npt.edn
@@ -37,21 +37,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "temperature" {

--- a/properties/phonon-dispersion-relation-cubic-crystal-npt/2014-05-21-staff@noreply.openkim.org/phonon-dispersion-relation-cubic-crystal-npt.edn
+++ b/properties/phonon-dispersion-relation-cubic-crystal-npt/2014-05-21-staff@noreply.openkim.org/phonon-dispersion-relation-cubic-crystal-npt.edn
@@ -37,21 +37,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "temperature" {

--- a/properties/structure-cubic-crystal-npt/2014-04-15-staff@noreply.openkim.org/structure-cubic-crystal-npt.edn
+++ b/properties/structure-cubic-crystal-npt/2014-04-15-staff@noreply.openkim.org/structure-cubic-crystal-npt.edn
@@ -37,21 +37,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "temperature" {

--- a/properties/structure-hexagonal-crystal-npt/2014-04-15-staff@noreply.openkim.org/structure-hexagonal-crystal-npt.edn
+++ b/properties/structure-hexagonal-crystal-npt/2014-04-15-staff@noreply.openkim.org/structure-hexagonal-crystal-npt.edn
@@ -44,21 +44,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "temperature" {

--- a/properties/structure-monoclinic-crystal-npt/2014-04-15-staff@noreply.openkim.org/structure-monoclinic-crystal-npt.edn
+++ b/properties/structure-monoclinic-crystal-npt/2014-04-15-staff@noreply.openkim.org/structure-monoclinic-crystal-npt.edn
@@ -58,21 +58,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "temperature" {

--- a/properties/structure-orthorhombic-crystal-npt/2014-04-15-staff@noreply.openkim.org/structure-orthorhombic-crystal-npt.edn
+++ b/properties/structure-orthorhombic-crystal-npt/2014-04-15-staff@noreply.openkim.org/structure-orthorhombic-crystal-npt.edn
@@ -51,21 +51,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "temperature" {

--- a/properties/structure-rhombohedral-crystal-npt/2014-04-15-staff@noreply.openkim.org/structure-rhombohedral-crystal-npt.edn
+++ b/properties/structure-rhombohedral-crystal-npt/2014-04-15-staff@noreply.openkim.org/structure-rhombohedral-crystal-npt.edn
@@ -44,21 +44,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "temperature" {

--- a/properties/structure-tetragonal-crystal-npt/2014-04-15-staff@noreply.openkim.org/structure-tetragonal-crystal-npt.edn
+++ b/properties/structure-tetragonal-crystal-npt/2014-04-15-staff@noreply.openkim.org/structure-tetragonal-crystal-npt.edn
@@ -44,21 +44,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "temperature" {

--- a/properties/structure-triclinic-crystal-npt/2014-04-15-staff@noreply.openkim.org/structure-triclinic-crystal-npt.edn
+++ b/properties/structure-triclinic-crystal-npt/2014-04-15-staff@noreply.openkim.org/structure-triclinic-crystal-npt.edn
@@ -72,21 +72,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "temperature" {

--- a/properties/surface-energy-broken-bond-fit-cubic-bravais-crystal-npt/2014-05-21-staff@noreply.openkim.org/surface-energy-broken-bond-fit-cubic-bravais-crystal-npt.edn
+++ b/properties/surface-energy-broken-bond-fit-cubic-bravais-crystal-npt/2014-05-21-staff@noreply.openkim.org/surface-energy-broken-bond-fit-cubic-bravais-crystal-npt.edn
@@ -30,21 +30,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [1]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [1,3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "temperature" {

--- a/properties/surface-energy-cubic-crystal-npt/2014-05-21-staff@noreply.openkim.org/surface-energy-cubic-crystal-npt.edn
+++ b/properties/surface-energy-cubic-crystal-npt/2014-05-21-staff@noreply.openkim.org/surface-energy-cubic-crystal-npt.edn
@@ -37,21 +37,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "temperature" {

--- a/properties/surface-energy-ideal-cubic-crystal/2014-05-21-staff@noreply.openkim.org/surface-energy-ideal-cubic-crystal.edn
+++ b/properties/surface-energy-ideal-cubic-crystal/2014-05-21-staff@noreply.openkim.org/surface-energy-ideal-cubic-crystal.edn
@@ -37,21 +37,21 @@
     "type"         "string"
     "has-unit"     false
     "extent"       []
-    "required"      false
+    "required"     false
     "description"  "Hermann-Mauguin designation for the space group associated with the symmetry of the crystal (e.g. Immm, Fm-3m, P6_3/mmc)."
   }
   "wyckoff-multiplicity-and-letter" {
     "type"         "string"
     "has-unit"     false
     "extent"       [":"]
-    "required"      false
+    "required"     false
     "description"  "Multiplicity and standard letter of Wyckoff sites (e.g. 4a, 2b).  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-coordinates'."
   }
   "wyckoff-coordinates" {
     "type"         "float"
     "has-unit"     false
     "extent"       [":",3]
-    "required"      false
+    "required"     false
     "description"  "Coordinates of the Wyckoff sites, given as fractions of the lattice vectors.  The order of elements in this array must correspond to the order of the entries listed in 'wyckoff-multiplicity-and-letter'."
   }
   "cauchy-stress" {


### PR DESCRIPTION
When I added the missing quotes around "required" before, I forgot to remove an extra trailing space that threw things out of alignment.  Strictly unnecessary, but aesthetically pleasing!
